### PR TITLE
[Chore] - Adicionando no-unused-vars correto para o typescript

### DIFF
--- a/templates/ts-lib-vite/.eslintrc.cjs
+++ b/templates/ts-lib-vite/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
       'error',
       'always', // Garante que declarações terminem com ponto e vírgula
     ],
-    'no-unused-vars': 'warn', // Adverte sobre variáveis declaradas mas não utilizadas
+    '@typescript-eslint/no-unused-vars': 'warn', // Adverte sobre variáveis declaradas mas não utilizadas no TypeScript
     'import/order': [
       'error',
       {


### PR DESCRIPTION
- Adiciona a regra do typescript e remove a de Js. Mantendo a de Javascript (no-unused-vars) ele dá erro em declarações de tipos e enums. Para consertar esse comportamento é necessário fazer a adição da regra especifica do Ts ('@typescript-eslint/no-unused-vars': 'warn')